### PR TITLE
Dropped TS version for node v12, added webpack-cli to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "ts-loader": "^9.0.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4",
-    "webpack": "^5.33.2"
+    "webpack": "^5.33.2",
+    "webpack-cli": "^4.6.0"
   },
   "dependencies": {
     "debug": "^4.3.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    "lib": ["es2020", "DOM"] /* Specify library files to be included in the compilation. */,
+    "lib": ["es2018", "DOM"] /* Specify library files to be included in the compilation. */,
     "resolveJsonModule": true,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
Tests on node 12.x were failing due to optional chaining syntax.