### PR TITLE
add invokeSync method

### DIFF
--- a/src/wapc-host.ts
+++ b/src/wapc-host.ts
@@ -104,6 +104,10 @@ export class WapcHost {
   }
 
   async invoke(operation: string, payload: Uint8Array): Promise<Uint8Array> {
+    return this.invokeSync(operation, payload)
+  }
+
+  invokeSync(operation: string, payload: Uint8Array): Uint8Array {
     debug(() => [`invoke(%o, [%o bytes]`, operation, payload.length]);
     const operationEncoded = this.textEncoder.encode(operation);
     this.state.guestRequest = { operation, operationEncoded, msg: payload };


### PR DESCRIPTION
This PR adds an `invokeSync` method that is similar to `invoke`, only executed synchronously.

The need for a synchronous method appeared for calling a WASM function from another WASM module. A small example:
```js
async function main() {
    buffer = await fs.readFile(path.join(__dirname, 'wasm', 'main.wasm'));
    const host = await instantiate(buffer);

    const policyWasm = await fs.readFile("policy.wasm");
    const policy = await loadPolicy(policyWasm, {}, {
        "greet": () => (msg) => {
            console.log("Message: ", msg);
            const payload = encode(msg);
            console.log("Payload: ", payload);
    
            res = host.invokeSync('greet', payload)
            return result = decode(res);
        }
    })

    const result = policy.evaluate({});
    console.log(JSON.stringify(result, null, 2));
}
```